### PR TITLE
Add "editExceptOuterLink"

### DIFF
--- a/src/utils/__test__/editExceptOuterLink-test.js
+++ b/src/utils/__test__/editExceptOuterLink-test.js
@@ -1,0 +1,65 @@
+import chai, { expect } from 'chai';
+import sinonChai from 'sinon-chai';
+import editExceptOuterLink, { isolate, retrieve, createPlaceholder } from '../editExceptOuterLink';
+
+chai.use(sinonChai);
+
+describe('editExceptOuterLink', () => {
+  const raw = `
+some :x: text
+<a href="http://example.com/:x:/a" target="_blank">http://example.com/:x:/a</a> <a href="https://example.com/:x:/b" target="_blank">https://example.com/:x:/b</a>
+<a href="http://example.com/:x:/a" target="_blank">http://example.com/:x:/a</a>
+`;
+  const isolated = `
+some :x: text
+<a href="http://${createPlaceholder(0)}" target="_blank">http://${createPlaceholder(1)}</a> <a href="http://${createPlaceholder(2)}" target="_blank">http://${createPlaceholder(3)}</a>
+<a href="http://${createPlaceholder(4)}" target="_blank">http://${createPlaceholder(5)}</a>
+`;
+  const placeholders = [
+    {
+      marking: `http://${createPlaceholder(0)}`,
+      replaced: 'http://example.com/:x:/a',
+    },
+    {
+      marking: `http://${createPlaceholder(1)}`,
+      replaced: 'http://example.com/:x:/a',
+    },
+    {
+      marking: `http://${createPlaceholder(2)}`,
+      replaced: 'https://example.com/:x:/b',
+    },
+    {
+      marking: `http://${createPlaceholder(3)}`,
+      replaced: 'https://example.com/:x:/b',
+    },
+    {
+      marking: `http://${createPlaceholder(4)}`,
+      replaced: 'http://example.com/:x:/a',
+    },
+    {
+      marking: `http://${createPlaceholder(5)}`,
+      replaced: 'http://example.com/:x:/a',
+    },
+  ];
+
+  it('isolate', () => {
+    expect(isolate(raw)).to.deep.equal({ isolated, placeholders });
+  });
+
+  it('retrieve', () => {
+    expect(retrieve(isolated, placeholders)).to.equal(raw);
+  });
+
+  it('editExceptOuterLink', () => {
+    /* eslint-disable max-len */
+    expect(editExceptOuterLink({
+      string: raw,
+      fn: (s) => s.replace(/:[a-z]+?:/g, 'replaced')
+    })).to.equal(`
+some replaced text
+<a href="http://example.com/:x:/a" target="_blank">http://example.com/:x:/a</a> <a href="https://example.com/:x:/b" target="_blank">https://example.com/:x:/b</a>
+<a href="http://example.com/:x:/a" target="_blank">http://example.com/:x:/a</a>
+`);
+    /* eslint-enable max-len */
+  });
+});

--- a/src/utils/editExceptOuterLink.js
+++ b/src/utils/editExceptOuterLink.js
@@ -1,0 +1,69 @@
+// @flow
+import { randomBytes } from 'crypto';
+
+const URL_PATTERN = new RegExp("(https?|ftp)(:\\/\\/[-_.!~*\\'()a-zA-Z0-9;\\/?:\\@&=+\\$,%#]+)", 'im');
+
+type Placeholder = {
+  marking: string,
+  replaced: string,
+};
+
+type Isolation = {
+  isolated: string,
+  placeholders: Placeholder[],
+}
+
+type EditExceptOuterLinkParameters = {
+  string: string,
+  fn: (s: string) => string,
+}
+
+const placeholderPrefix = randomBytes(16).toString('hex');
+
+export function createPlaceholder(id: number): string {
+  return `replacement-${placeholderPrefix}-${id}.com/placeholder`;
+}
+
+export function isolate(raw: string): Isolation {
+  const placeholders: Placeholder[] = [];
+
+  let isolated = raw;
+  for (
+    let i = 0, matched = isolated.match(URL_PATTERN);
+    matched;
+    matched = isolated.match(URL_PATTERN)
+  ) {
+    const marking = createPlaceholder(i++);
+    const replaced = matched[0];
+    isolated = isolated.replace(replaced, marking);
+    placeholders.push({
+      marking,
+      replaced,
+    });
+  }
+
+  // add 'http://' prefix to placeholders for url management features.
+  placeholders.forEach((set) => {
+    const marking = `http://${set.marking}`;
+    isolated = isolated.replace(set.marking, marking);
+    set.marking = marking; // eslint-disable-line no-param-reassign
+  });
+
+  return {
+    isolated,
+    placeholders,
+  };
+}
+
+export function retrieve(isolated: string, placeholders: Placeholder[]): string {
+  return placeholders.reduce(
+    (a, { marking, replaced }) => a.replace(marking, replaced),
+    isolated,
+  );
+}
+
+export default function editExceptOuterLink({ string, fn }: EditExceptOuterLinkParameters): string {
+  const { isolated, placeholders } = isolate(string);
+  const edited = fn(isolated);
+  return retrieve(edited, placeholders);
+}


### PR DESCRIPTION
# 問題

[\[COMUQUE\-1177\] 【ユーザー】URLに:x:が入っていると、絵文字になる \- Jira](https://oneteam-dev.atlassian.net/browse/COMUQUE-1177)

これは viewer 部での指摘だが、再編集を行おうとすると editor 内で同現象が起こる。

# 原因

editor に渡す EditorState 作成には oneteam-rte の `htmlToContent` を用い、その中で `emojione.toShort(str)` により `:emoji:` が任意の絵文字コードに変換される。

このメソッドは区別なく絵文字置換するが、url に含まれていた場合 (attribute のものは除外されるが) 表示 url が変わってしまう。

# 対応

そのためリンクタグを隔離し保護する `editExceptOuterLink` を追加する。

## oneteam-rte に適用し `getPlainText` した結果 (コンソール部参照)

![image](https://user-images.githubusercontent.com/2605710/47759507-4f46be00-dcf3-11e8-8627-7ad69a55c916.png)

## 従来の処理ではこうなる

![image](https://user-images.githubusercontent.com/2605710/47759775-88336280-dcf4-11e8-9632-456b1956900a.png)
